### PR TITLE
hot fix in tf throttle timestamp when taking snapshot

### DIFF
--- a/tf_throttle/src/tf_throttle.cpp
+++ b/tf_throttle/src/tf_throttle.cpp
@@ -45,6 +45,7 @@ void sendTransforms()
 
 		geometry_msgs::TransformStamped m;
 		tf::transformStampedTFToMsg(transform, m);
+		m.header.stamp = ros::Time::now();
 
 		msg.transforms.push_back(m);
 	}


### PR DESCRIPTION
This PR fixes a timing issue when taking a snapshot of tf.

While testing tf_throttle with Ubuntu 18.04 and ROS Melodic, I noticed that I was not able to visualize the tf topic in rviz (plus roswtf was complaining about a a super old tf), even though the message was correctly populated. It turned out that when taking the snapshot, the timestamp in the header must be set, otherwise 0 is used per default.